### PR TITLE
include routing for static and media files on nginx ssl config

### DIFF
--- a/config/nginx/ssl/qgisfeed.conf
+++ b/config/nginx/ssl/qgisfeed.conf
@@ -59,6 +59,14 @@ server {
                 try_files $uri @qgisfeed;
         }
 
+	location /static/ {
+                root /shared-volume/;
+        }
+
+        location /media/ {
+                root /shared-volume/;
+        }
+
         location @qgisfeed {
                 proxy_pass http://web;
                 add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
This pull request fix #1  by updating routing configuration on https request for static and media files.

cc @timlinux 