### PR TITLE
issue #10, replace rich text editor with raw text area

### DIFF
--- a/qgisfeedproject/qgisfeed/models.py
+++ b/qgisfeedproject/qgisfeed/models.py
@@ -48,7 +48,7 @@ class QgisFeedEntry(models.Model):
 
     title = models.CharField(_('Title'), max_length=255)
     image = ProcessedImageField([ResizeToFill(500, 354)], 'JPEG', {'quality': 60}, _('Image'),upload_to='feedimages/%Y/%m/%d/', height_field='image_height', width_field='image_width', max_length=None, blank=True, null=True, help_text=_('Landscape orientation, image will be cropped and scaled automatically to 500x354 px') )
-    content = tinymce_models.HTMLField()
+    content = models.TextField()
     url = models.URLField(_('URL'), max_length=200, help_text=_('URL for more information link'))
 
     # Auto fields


### PR DESCRIPTION
This PR is referring to issue #10.
User has had issue with formatted code being pasted in news entries which breaks the display/layout of the item on the QGIS client. And propose to remove rich text editor and replace it with a raw html entry box.

According to the issue description, this PR replaced tinymce editor with django model.TexfField() so that text editor in admin page will be raw textarea input field.

**Before, was using rich text editor:**
<img width="535" alt="Screenshot 2020-09-30 at 9 24 50 AM" src="https://user-images.githubusercontent.com/40058076/94633478-f5e0d280-02ff-11eb-9f11-a9a558dea7a7.png">

**After replaced with raw textarea field:**
<img width="535" alt="Screenshot 2020-09-30 at 9 25 18 AM" src="https://user-images.githubusercontent.com/40058076/94633408-bc0fcc00-02ff-11eb-8db4-fc0f41ac6180.png">


