### PR TITLE
Use contry code when testing daily_visit.country

### DIFF
--- a/qgisfeedproject/qgisfeed/tests.py
+++ b/qgisfeedproject/qgisfeed/tests.py
@@ -299,7 +299,7 @@ class QgisUserVisitTestCase(TestCase):
         daily_visit = DailyQgisUserVisit.objects.first()
         self.assertTrue(daily_visit.platform['Windows 10'] == 1)
         self.assertTrue(daily_visit.qgis_version['32400'] == 2)
-        self.assertTrue(daily_visit.country['Indonesia'] == 3)
+        self.assertTrue(daily_visit.country['ID'] == 3)
 
 
 class LoginTestCase(TestCase):


### PR DESCRIPTION
@dimasciput, The test generates a key error on the `contry_name` since the `country_code` is used here: https://github.com/qgis/qgis-feed/blob/94e2ad306584b682ee7d12be5bd7b4542827bd08/qgisfeedproject/qgisfeed/models.py#L225 

I have made an update in the test file by using the `country_code`. However, I wonder if this has an impact somewhere else (feed analytics for example).