### PR TITLE
Remove lat&long filters in home page

### DIFF
--- a/qgisfeedproject/qgisfeed/forms.py
+++ b/qgisfeedproject/qgisfeed/forms.py
@@ -18,16 +18,6 @@ class HomePageFilterForm(forms.Form):
         widget=forms.Select()
     )
 
-    lat = forms.FloatField(
-        required=False,
-        widget=forms.NumberInput(attrs={'class': 'input', 'placeholder': 'Latitude'})
-    )
-
-    lon = forms.FloatField(
-        required=False,
-        widget=forms.NumberInput(attrs={'class': 'input', 'placeholder': 'Longitude'})
-    )
-
     publish_from = forms.CharField(
         required=False,
         widget=forms.DateInput(

--- a/qgisfeedproject/qgisfeed/tests.py
+++ b/qgisfeedproject/qgisfeed/tests.py
@@ -268,8 +268,6 @@ class HomePageTestCase(TestCase):
 
         data = {
             'lang': 'en',
-            'lat': -19,
-            'lon': 47,
             'publish_from': '2023-12-31',
         }
         response = self.client.get(reverse('all'), data)

--- a/qgisfeedproject/templates/feeds/feed_home_page.html
+++ b/qgisfeedproject/templates/feeds/feed_home_page.html
@@ -51,26 +51,6 @@
                     </div>
     
                     <div class="field">
-                        <label class="label">Latitude:</label>
-                        <div class="control has-icons-left">
-                            {{form.lat}}
-                            <span class="icon is-small is-left">
-                              <i class="fas fa-map-pin"></i>
-                            </span>
-                        </div>
-                    </div>
-    
-                    <div class="field">
-                        <label class="label">Longitude:</label>
-                        <div class="control has-icons-left">
-                            {{form.lon}}
-                            <span class="icon is-small is-left">
-                              <i class="fas fa-map-pin"></i>
-                            </span>
-                        </div>
-                    </div>
-    
-                    <div class="field">
                         <label class="label">Date published from:</label>
                         <div class="control has-icons-left">
                           {{form.publish_from}}


### PR DESCRIPTION
- Fix for #52 
Please find below a screenshot of the homepage after removing the lat&long filters:

![Screenshot 2023-11-21 at 7 38 20 AM](https://github.com/qgis/qgis-feed/assets/43842786/c78f47c4-9943-4f26-8c92-6bf1ff132e24)
