### PR TITLE
Upgrade to Django 4 to fix OL map

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -6,10 +6,10 @@ asynctest==0.13.0
 attrs==21.4.0
 certifi==2021.10.8
 charset-normalizer==2.0.12
-Django==3.2.11
+Django==4.2.8
 django-appconf==1.0.3
 django-extensions==3.1.5
-django-imagekit==4.0.2
+django-imagekit==5.0.0
 django-tinymce==3.6.1
 django-user-visit==0.5.1
 django-webpack-loader==2.0.1
@@ -20,7 +20,7 @@ maxminddb==2.2.0
 multidict==6.0.2
 pilkit==2.0
 Pillow==6.1.0
-psycopg2==2.8.3
+psycopg2==2.9.9
 pytz==2019.2
 requests==2.27.1
 six==1.12.0

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,6 +1,6 @@
 aiohttp==3.8.1
 aiosignal==1.2.0
-asgiref==3.5.0
+asgiref==3.7.2
 async-timeout==4.0.2
 asynctest==0.13.0
 attrs==21.4.0
@@ -24,7 +24,7 @@ psycopg2==2.9.9
 pytz==2019.2
 requests==2.27.1
 six==1.12.0
-sqlparse==0.3.0
+sqlparse==0.4.4
 typing-extensions==4.1.1
 ua-parser==0.10.0
 urllib3==1.26.9


### PR DESCRIPTION
- This PR is addressing the following issue: #56 

I suspected mismatched Django versions between my local and the production environment. I noticed that the OpenLayers map in the `Set spatial filter` modal doesn't show when using Django 3. I've tried the current and the last patched version (3.2.11 and 3.2.23). It works fine after upgrading to Django 4.2.8.

## Changes summary:
- Upgrade to Django 4, and update some dependencies in the requirements. 

## Requirement:
- These changes require a build on the server side. 

Please find below the screenshot of the `Set spatial filter` modal when using Django 4:

![image](https://github.com/qgis/qgis-feed/assets/43842786/d5e91c04-4310-4c21-ab02-cdb7679d9bd9)
