### PR TITLE
Add dbbackups service to docker-compose

### DIFF
--- a/docker-compose-production-ssl.yml
+++ b/docker-compose-production-ssl.yml
@@ -102,6 +102,22 @@ services:
     depends_on:
       - nginx
     command: certonly --webroot --webroot-path=/var/www/webroot --email admin@qgis.org --agree-tos --no-eff-email --force-renewal -d feed.qgis.org
+  
+  dbbackups:
+    image: kartoza/pg-backup:11.0
+    environment:
+      DUMPPREFIX: PG_QGIS_FEED
+      POSTGRES_DATABASE: ${QGISFEED_DOCKER_DBNAME}
+      POSTGRES_HOST: postgis
+      POSTGRES_PASSWORD: ${QGISFEED_DOCKER_DBPASSWORD}
+      POSTGRES_PORT: '5432'
+      POSTGRES_USER: ${QGISFEED_DOCKER_DBUSER}
+    volumes:
+    - /mnt/backups/:/backups
+    links:
+    - postgis:postgis
+    command:
+    - /start.sh
 
 networks:
     internal:


### PR DESCRIPTION
- This PR is for the issue #64 

## Changes summary

- Add dbbackups service to docker-compose
- Use the volume `/mnt/backups/` for backups