### PR TITLE
Use python 3.8 to install Django 4

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,8 +1,8 @@
-FROM python:3
+FROM python:3.8-slim
 ENV PYTHONUNBUFFERED 1
 
 RUN echo "Installing GDAL dependencies" && \
-    apt-get update && apt install -y libgdal20 wait-for-it && \
+    apt-get update && apt install -y libgdal-dev wait-for-it && \
     echo "Install C library for geoip2" && \
     apt-get install -y libmaxminddb0 libmaxminddb-dev mmdb-bin
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,22 @@ $ docker-compose -f docker-compose.dev.yml exec qgisfeed python qgisfeedproject/
 
 ## Deployment
 <details>
+    <summary><strong>Deploy changes</strong></summary>
+    </br>
+
+- Pull the latest commit: `git pull origin master`
+
+nano docker-compose-production-ssl.yml 
+docker-compose -f docker-compose-production-ssl.yml build qgisfeed
+docker-compose -f docker-compose-production-ssl.yml up -d qgisfeed
+docker-compose -f docker-compose-production-ssl.yml exec qgisfeed /bin/bash
+python manage.py migrate
+qgisfeed:production-1.3
+qgisfeed:production-1.1
+
+</details>
+
+<details>
     <summary><strong>Troubleshooting SSL in production</strong></summary>
     </br>
 

--- a/README.md
+++ b/README.md
@@ -298,22 +298,6 @@ $ docker-compose -f docker-compose.dev.yml exec qgisfeed python qgisfeedproject/
 
 ## Deployment
 <details>
-    <summary><strong>Deploy changes</strong></summary>
-    </br>
-
-- Pull the latest commit: `git pull origin master`
-
-nano docker-compose-production-ssl.yml 
-docker-compose -f docker-compose-production-ssl.yml build qgisfeed
-docker-compose -f docker-compose-production-ssl.yml up -d qgisfeed
-docker-compose -f docker-compose-production-ssl.yml exec qgisfeed /bin/bash
-python manage.py migrate
-qgisfeed:production-1.3
-qgisfeed:production-1.1
-
-</details>
-
-<details>
     <summary><strong>Troubleshooting SSL in production</strong></summary>
     </br>
 

--- a/docker-compose-production-ssl.yml
+++ b/docker-compose-production-ssl.yml
@@ -62,6 +62,7 @@ services:
       - "8000"
     volumes:
       - ${QGISFEED_DOCKER_SHARED_VOLUME}:/shared-volume
+      - ../qgis-feed:/code
     depends_on:
       - postgis
     logging:

--- a/docker-compose-production-ssl.yml
+++ b/docker-compose-production-ssl.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
 
   postgis:
-    image: kartoza/postgis:11.0-2.5
+    image: kartoza/postgis:16-3.4
     ports:
       - "5432"
     environment:
@@ -16,6 +16,8 @@ services:
         max-size: "200k"
         max-file: "10"
     restart: always
+    healthcheck:
+      test: "POSTGRES_PASS=$${QGISFEED_DOCKER_DBPASSWORD} pg_isready -h 127.0.0.1 -U ${QGISFEED_DOCKER_DBUSER} -d ${QGISFEED_DOCKER_DBNAME}"
     volumes:
       - ${QGISFEED_DOCKER_SHARED_VOLUME}:/var/lib/postgresql
     networks:
@@ -47,7 +49,7 @@ services:
   qgisfeed:
     # Note you cannot scale if you use container_name
     container_name: qgisfeed
-    image: qgisfeed:production
+    image: xpirix/qgisfeed:production-1.4
     build:
       context: .
       dockerfile: Dockerfile.production
@@ -104,20 +106,22 @@ services:
     command: certonly --webroot --webroot-path=/var/www/webroot --email admin@qgis.org --agree-tos --no-eff-email --force-renewal -d feed.qgis.org
   
   dbbackups:
-    image: kartoza/pg-backup:11.0
+    image: kartoza/pg-backup:16-3.4
     environment:
       DUMPPREFIX: PG_QGIS_FEED
       POSTGRES_DATABASE: ${QGISFEED_DOCKER_DBNAME}
       POSTGRES_HOST: postgis
-      POSTGRES_PASSWORD: ${QGISFEED_DOCKER_DBPASSWORD}
+      POSTGRES_PASS: ${QGISFEED_DOCKER_DBPASSWORD}
       POSTGRES_PORT: '5432'
       POSTGRES_USER: ${QGISFEED_DOCKER_DBUSER}
     volumes:
     - /mnt/backups/:/backups
-    links:
-    - postgis:postgis
-    command:
-    - /start.sh
+    restart: on-failure
+    depends_on:
+      postgis:
+        condition: service_healthy
+    networks:
+      internal:
 
 networks:
     internal:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
 
   postgis:
-    image: kartoza/postgis:11.0-2.5
+    image: kartoza/postgis:16-3.4
     ports:
     - "5432"
     environment:
@@ -47,7 +47,7 @@ services:
   qgisfeed:
     # Note you cannot scale if you use container_name
     container_name: qgisfeed
-    image: qgisfeed:production
+    image: xpirix/qgisfeed:production-1.4
     build:
       context: .
       dockerfile: Dockerfile.production
@@ -84,6 +84,24 @@ services:
       - ${QGISFEED_DOCKER_SHARED_VOLUME}:/shared-volume
       - ./config/nginx:/etc/nginx/conf.d
     restart: always
+    networks:
+      internal:
+
+  dbbackups:
+    image: kartoza/pg-backup:16-3.4
+    environment:
+      DUMPPREFIX: PG_QGIS_FEED
+      POSTGRES_DATABASE: ${QGISFEED_DOCKER_DBNAME}
+      POSTGRES_HOST: postgis
+      POSTGRES_PASS: ${QGISFEED_DOCKER_DBPASSWORD}
+      POSTGRES_PORT: '5432'
+      POSTGRES_USER: ${QGISFEED_DOCKER_DBUSER}
+    volumes:
+    - /mnt/backups/:/backups
+    restart: on-failure
+    depends_on:
+      postgis:
+        condition: service_healthy
     networks:
       internal:
 

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -18,6 +18,7 @@ services:
     restart: always
     volumes:
       - ${QGISFEED_DOCKER_SHARED_VOLUME}:/var/lib/postgresql
+      - ../qgis-feed:/code
     networks:
       internal:
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   postgis:
-    image: kartoza/postgis:14-3.1
+    image: kartoza/postgis:16-3.4
     platform: linux/amd64
     environment:
       POSTGRES_USER: docker


### PR DESCRIPTION
According to #56 and #61 , we should use Django 4 to fix the spatial filter map. I think this is also an opportunity to upgrade to the new LTS because version 3.2 extended support will end in April 2024.

## Current situation

- This version of Django needs Python 3.8+.
- In production, the build raises an error when using the Python 3.8 image:
```
The following signatures couldn't be verified because the public key is not available: NO_PUBKEY <the_pubkey> 
```

## Proposed fixes

- Upgrade to Python 3.8 and Django 4. I pushed the image on the Docker hub (`xpirix/qgisfeed:production-1.4`) so we don't have to upgrade the Docker version or build it on the server.
- Upgrade to Postgresql 16 because Django 4 depends on 12+ (The current version is 11).

EDIT: I also added the code folder in the mounted volume so we don't have to build the image to have each change inside the container.