### PR TITLE
Allow xx_XX lang in parameter

### DIFF
--- a/qgisfeedproject/qgisfeed/tests.py
+++ b/qgisfeedproject/qgisfeed/tests.py
@@ -127,6 +127,12 @@ class QgisFeedEntryTestCase(TestCase):
         self.assertTrue("Null Island QGIS Meeting" in titles)
         self.assertTrue("QGIS acquired by ESRI" in titles)
 
+        response = c.get('/?lang=en_US')
+        data = json.loads(response.content)
+        titles = [d['title'] for d in data]
+        self.assertTrue("Null Island QGIS Meeting" in titles)
+        self.assertTrue("QGIS acquired by ESRI" in titles)
+
     def test_lat_lon_filter(self):
         c = Client(HTTP_USER_AGENT='Mozilla/5.0 QGIS/32400/Fedora '
                                    'Linux (Workstation Edition)')
@@ -174,6 +180,8 @@ class QgisFeedEntryTestCase(TestCase):
         response = c.get('/?lat=ZZ&lon=KK')
         self.assertEqual(response.status_code, 400)
         response = c.get('/?lang=KK')
+        self.assertEqual(response.status_code, 400)
+        response = c.get('/?lang=english')
         self.assertEqual(response.status_code, 400)
 
     def test_image_link(self):

--- a/qgisfeedproject/qgisfeed/views.py
+++ b/qgisfeedproject/qgisfeed/views.py
@@ -66,8 +66,8 @@ class QgisEntriesView(View):
         """
         filters = {}
         if request.GET.get('lang'):
-            lang = request.GET.get('lang')
-            if not lang in LANGUAGE_KEYS:
+            lang = str(request.GET.get('lang'))[:2]
+            if lang not in LANGUAGE_KEYS:
                 raise BadRequestException("Invalid language parameter.")
             filters['lang'] = lang
         if request.GET.get('lat') and request.GET.get('lon'):

--- a/qgisfeedproject/qgisfeed/views.py
+++ b/qgisfeedproject/qgisfeed/views.py
@@ -37,6 +37,8 @@ import json
 from user_visit.models import UserVisit
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
+import re
+
 
 QGISFEED_MAX_RECORDS=getattr(settings, 'QGISFEED_MAX_RECORDS', 20)
 
@@ -66,8 +68,15 @@ class QgisEntriesView(View):
         """
         filters = {}
         if request.GET.get('lang'):
-            lang = str(request.GET.get('lang'))[:2]
-            if lang not in LANGUAGE_KEYS:
+            lang = request.GET.get('lang')
+            # Define the regular expression pattern for 'xx' or 'xx_XX'
+            pattern = re.compile(r'^[a-z]{2}(_[A-Z]{2})?$')
+            if pattern.match(lang):
+                # Get the first two letters of the language code
+                lang = lang[:2]
+                if lang not in LANGUAGE_KEYS:
+                    raise BadRequestException("Invalid language parameter.")
+            else:
                 raise BadRequestException("Invalid language parameter.")
             filters['lang'] = lang
         if request.GET.get('lat') and request.GET.get('lon'):


### PR DESCRIPTION
Fix for #13 

- Match the lang parameter with xx and xx_XX pattern
- Get only the first two letters from the language parameter
- Update unit tests