### PR TITLE
Feed buttons

### DIFF
--- a/qgisfeedproject/templates/feeds/feed_home_page.html
+++ b/qgisfeedproject/templates/feeds/feed_home_page.html
@@ -84,21 +84,34 @@
                 <div class="tab-content-element is-active" style="padding:0 10px;" data-content="1">
                     {% if data|length > 0 %}
                     {% for feed in data %}
-                    <div class="box-container hoverable-preview form-preview columns has-background-light p-2 mt-5"
-                        onclick="window.location.href='{% url 'feed_detail' feed.pk %}';" style="margin-left: auto;margin-right: auto;">
+                    <div class="box-container form-preview columns has-background-light p-2 mt-5 {% if feed.url %}hoverable-preview{% endif %}"
+                        {% if feed.url %}ondblclick="window.open('{{ feed.url }}', '_blank');"{% endif %} style="margin-left: auto;margin-right: auto;">
                         <div class="column is-4 is-flex is-flex-direction-column is-align-items-center"
                             name="imagePreview">
                             {% if feed.image %}
                             <img src="{{ feed.image }}" style="border-radius:20px;">
                             {% endif %}
                         </div>
-                        <div class="column is-8">
+                        <div class="column is-8 is-flex is-flex-direction-column is-justify-content-space-between">
                             <h5 name="titlePreview" class="title is-5">
                                 {{feed.title | default:""}}
                             </h5>
                             <div name="contentPreview">
                                 {{feed.content | default:"" | safe }}
                             </div>
+                            <div class="is-flex is-justify-content-flex-end mt-3" style="gap: 10px;">
+                                {% if feed.url %}
+                                <a class="button" href="{{ feed.url }}" target="_blank">
+                                    <span class="icon"><i class="fa fa-arrow-up-right-from-square"></i></span>
+                                    <span>Open the URL</span>
+                                </a>
+                                {% endif %}
+                                <a class="button" href="{% url 'feed_detail' feed.pk %}">
+                                    <span class="icon"><i class="fa fa-info-circle"></i></span>
+                                    <span>More details</span>
+                                </a>
+                            </div>
+                                
                         </div>
                     </div>
                     {% endfor %}

--- a/qgisfeedproject/templates/feeds/feed_item_detail.html
+++ b/qgisfeedproject/templates/feeds/feed_item_detail.html
@@ -6,7 +6,18 @@
 {% endblock stylesheets %}
 {% block content %}
 
+
 <div class="m-5">
+    <div class="columns is-centered">
+        <div class="column is-8 box-container">
+            <a href="{% url 'all' %}" class="button">
+                <span class="icon">
+                    <i class="fas fa-arrow-left"></i>
+                </span>
+                <span>Back to Feed List</span>
+            </a>
+        </div>
+    </div>
     <div class="columns is-centered">
         <div class="form-preview column is-8 has-background-light p-2 box-container m-5">
             <div class="columns">
@@ -41,28 +52,6 @@
                                 <i>-</i>
                             {% endif %}
                             <p class="help">URL for more information link</p>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>Sticky:</th>
-                        <td name="stickyPreview">
-                            {% if feed_entry.sticky %}
-                                <span class="icon has-text-success">
-                                    <i class="fa-solid fa-circle-check"></i>
-                                </span>
-                            {% else %}
-                                <span class="icon has-text-danger">
-                                    <i class="fa-solid fa-circle-xmark"></i>
-                                </span>
-                            {% endif %}
-                            <p class="help">Keep this entry on top</p>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>Sorting order:</th>
-                        <td name="sortingPreview">
-                            {{ feed_entry.sorting|default:"-" }}
-                            <p class="help">Order to show at top of the list</p>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Fix for #98 

- Added `Open the URL` button: open the feed's url in a new tab
- Added `More details` button: open a feed's details page
- Open the feed's url in a new tab when double clicking on an entry
- Add `Back to feed list` button on each feed's details page

![image](https://github.com/user-attachments/assets/288c5fd9-34fa-4d3b-a595-154898e193ce)
