### PR TITLE
Add guidelines for feed submission

### DIFF
--- a/qgisfeedproject/qgisfeed/forms.py
+++ b/qgisfeedproject/qgisfeed/forms.py
@@ -97,7 +97,8 @@ class FeedItemForm(forms.ModelForm):
 
     sticky = forms.BooleanField(
         required=False,
-        widget=forms.CheckboxInput(attrs={'class': 'checkbox'})
+        widget=forms.CheckboxInput(attrs={'class': 'checkbox'}),
+        help_text="Do not mark the entry as sticky unless it is urgent."
     )
 
     approvers = forms.MultipleChoiceField(
@@ -149,7 +150,7 @@ class FeedItemForm(forms.ModelForm):
                 'class': 'input', 
                 }
         )
-        self.fields['publish_to'].initial = timezone.now() + timezone.timedelta(days=30)
+        self.fields['publish_to'].initial = timezone.now() + timezone.timedelta(days=10)
         self.fields['approvers'].choices = self.get_approvers_choices()
 
     def clean_content(self):

--- a/qgisfeedproject/static/js/bulma.js
+++ b/qgisfeedproject/static/js/bulma.js
@@ -8,4 +8,49 @@ document.addEventListener("DOMContentLoaded", () => {
       });
     }
   );
+
+  // Functions to open and close the review modal
+  function openModal($el) {
+    $el.classList.add("is-active");
+  }
+
+  function closeModal($el) {
+    $el.classList.remove("is-active");
+  }
+
+  function closeAllModals() {
+    (document.querySelectorAll(".modal") || []).forEach(($modal) => {
+      closeModal($modal);
+    });
+  }
+
+  // Add a click event on buttons to open the modal
+  (document.querySelectorAll(".js-modal-trigger") || []).forEach(($trigger) => {
+    const modal = $trigger.dataset.target;
+    const $target = document.getElementById(modal);
+
+    $trigger.addEventListener("click", () => {
+      openModal($target);
+    });
+  });
+
+  // Add a click event on various child elements to close the parent modal
+  (
+    document.querySelectorAll(
+      ".modal-background, .modal-close, .modal-card-head .delete, .modal-card-foot .button"
+    ) || []
+  ).forEach(($close) => {
+    const $target = $close.closest(".modal");
+
+    $close.addEventListener("click", () => {
+      closeModal($target);
+    });
+  });
+
+  // Add a keyboard event to close all modals
+  document.addEventListener("keydown", (event) => {
+    if (event.code === "Escape") {
+      closeAllModals();
+    }
+  });
 });

--- a/qgisfeedproject/templates/feeds/feed_item_confirmation.html
+++ b/qgisfeedproject/templates/feeds/feed_item_confirmation.html
@@ -7,17 +7,22 @@
         </header>
         <section class="modal-card-body">
             {% include 'feeds/feed_item_preview.html' %}
+            {% if not published and user_is_approver and form.instance.pk %}
+            <div>
+                <div class="notification is-warning is-light">
+                    Before you publish this item, please ensure that you have reviewed the content and 
+                    the entry adheres to the following guidelines:
+                    {% include "feeds/guidelines_content.html" %}
+                    </div>
+                <p class="notification is-danger is-light">
+                    Please note: When you publish this item it will be cached on the QGIS client side. 
+                    Any subsequent changes you make to this posting will not be propagated to clients 
+                    that have already cached this post. So double check everything one more time before 
+                    publishing please!
+                </p>
+            </div>
         </section>
 
-        {% if not published and user_is_approver and form.instance.pk %}
-        <div>
-            <p class="notification is-danger">
-                Please note: When you publish this item it will be cached on the QGIS client side. 
-                Any subsequent changes you make to this posting will not be propagated to clients 
-                that have already cached this post. So double check everything one more time before 
-                publishing please!
-            </p>
-        </div>
         {% endif %}
         <footer class="modal-card-foot is-justify-content-flex-end">
             <button class="button">

--- a/qgisfeedproject/templates/feeds/feed_item_detail.html
+++ b/qgisfeedproject/templates/feeds/feed_item_detail.html
@@ -12,7 +12,7 @@
     <span class="icon">
         <i class="fas fa-arrow-left"></i>
     </span>
-    <span>Back to Feed List</span>
+    <span>Back to the list</span>
 </a>
 
     {% include "feeds/feed_rich_item.html" with feed=feed_entry show_buttons=0 %}

--- a/qgisfeedproject/templates/feeds/feed_item_form.html
+++ b/qgisfeedproject/templates/feeds/feed_item_form.html
@@ -40,16 +40,16 @@
 
 <h1 class="title">
     {% if form.title.value %}
-        Edit feed item
+        Edit feed entry
     {% else %}
-        New feed item
+        New feed entry
     {% endif %}
 </h1>
 <a href="{% url 'feeds_list' %}" class="button">
     <span class="icon">
         <i class="fas fa-arrow-left"></i>
     </span>
-    <span>Back to Feed List</span>
+    <span>Back to the list</span>
 </a>
 
 <div class="columns is-multiline is-centered mt-3 ">

--- a/qgisfeedproject/templates/feeds/feed_item_form_widgets.html
+++ b/qgisfeedproject/templates/feeds/feed_item_form_widgets.html
@@ -100,18 +100,21 @@
         {% endfor %}
       </div>
       <div class="column is-6 field">
-        <label class="label"> 
-          {% if form.sticky.field.required %}
-              <span style="color:red;">*</span>
+        {% if user_is_approver %}
+          <label class="label"> 
+            {% if form.sticky.field.required %}
+                <span style="color:red;">*</span>
+            {% endif %}
+            Sticky: 
+          </label>
+          <div class="control is-flex is-align-items-center" style="height:2.5em;">
+            <label class="checkbox"> {{form.sticky}} Keep this entry on top </label>
+          </div>
+          <p class="help">{{form.sticky.help_text}}</p>
+          {% for error in form.sticky.errors %}
+            <p class="help form-error">{{ error }}</p>
+          {% endfor %}
           {% endif %}
-          Sticky: 
-        </label>
-        <div class="control is-flex is-align-items-center" style="height:2.5em;">
-          <label class="checkbox"> {{form.sticky}} Keep this entry on top </label>
-        </div>
-        {% for error in form.sticky.errors %}
-          <p class="help form-error">{{ error }}</p>
-        {% endfor %}
       </div>
     </div>
 

--- a/qgisfeedproject/templates/feeds/feeds_list.html
+++ b/qgisfeedproject/templates/feeds/feeds_list.html
@@ -18,22 +18,22 @@
     QGIS Feed Management
 </h1>
 
+{% include 'feeds/guidelines_modal.html' %}
 
   <div class="is-flex is-justify-content-space-between" style="gap: 10px;">
     {% if user_can_add %}
-    <button 
-        class="button is-primary1"
-        value="add" 
-        onclick="window.location.href='{% url 'feed_entry_add'%}';"
-    >
-    <span class="icon">
-      <i class="fas fa-plus" aria-hidden="true"></i>
-    </span>
-    <span>New feed</span>
-         
-    </button>
+      <button 
+          class="button is-primary1 js-modal-trigger"
+          data-target="guidelinesModal"
+      >
+        <span class="icon">
+          <i class="fas fa-plus" aria-hidden="true"></i>
+        </span>
+        <span>New entry</span>
+          
+      </button>
 
-{% endif %}
+    {% endif %}
     <button 
         id="filter-button"
         class="button is-primary1 is-outlined"

--- a/qgisfeedproject/templates/feeds/guidelines_content.html
+++ b/qgisfeedproject/templates/feeds/guidelines_content.html
@@ -1,0 +1,16 @@
+<ul>
+  <li>
+    Each entry must be reviewed by at least
+    <span class="has-text-weight-bold">two people</span> before publishing.
+  </li>
+  <li>
+    The maximum duration for an entry should not exceed
+    <span class="has-text-weight-bold">10 days</span>.
+  </li>
+  <li>
+    Do not mark the entry as
+    <span class="has-text-weight-bold">sticky</span> unless it is urgent. Only
+    an <span class="has-text-weight-bold">approver</span> can make an entry
+    sticky.
+  </li>
+</ul>

--- a/qgisfeedproject/templates/feeds/guidelines_modal.html
+++ b/qgisfeedproject/templates/feeds/guidelines_modal.html
@@ -1,0 +1,34 @@
+<div id="guidelinesModal" class="modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+        <div class="container rich m-0">
+          <div class="cont coloring-2">
+              <h2>Before Submitting a New Feed Entry</h2>
+              <p>Please ensure you adhere to the following guidelines:</p>
+                <ul>
+                <li>Each entry must be reviewed by at least <span class="has-text-weight-bold">two people</span> before publishing.</li>
+                <li>The maximum duration for an entry should not exceed <span class="has-text-weight-bold">10 days</span>.</li>
+                <li>Do not mark the entry as <span class="has-text-weight-bold">sticky</span> unless it is urgent. 
+                  Only an <span class="has-text-weight-bold">approver</span> can make an entry sticky.</li>
+                </ul>
+          </div>
+        </div>
+
+        <footer class="modal-card-foot is-justify-content-flex-end" style="top: -10px;">
+            <button class="button">
+          <span class="icon">
+              <i class="fas fa-arrow-left" aria-hidden="true"></i>
+          </span>
+          <span>Return to List</span>
+            </button>
+            <button class="button is-success"
+              value="add" 
+              onclick="window.location.href='{% url 'feed_entry_add'%}';">
+          <span class="icon">
+              <i class="fas fa-check-circle" aria-hidden="true"></i>
+          </span>
+          <span>Got it</span>
+            </button>
+        </footer>
+    </div>
+</div>

--- a/qgisfeedproject/templates/feeds/guidelines_modal.html
+++ b/qgisfeedproject/templates/feeds/guidelines_modal.html
@@ -5,12 +5,7 @@
           <div class="cont coloring-2">
               <h2>Before Submitting a New Feed Entry</h2>
               <p>Please ensure you adhere to the following guidelines:</p>
-                <ul>
-                <li>Each entry must be reviewed by at least <span class="has-text-weight-bold">two people</span> before publishing.</li>
-                <li>The maximum duration for an entry should not exceed <span class="has-text-weight-bold">10 days</span>.</li>
-                <li>Do not mark the entry as <span class="has-text-weight-bold">sticky</span> unless it is urgent. 
-                  Only an <span class="has-text-weight-bold">approver</span> can make an entry sticky.</li>
-                </ul>
+                {% include "feeds/guidelines_content.html" %}
           </div>
         </div>
 

--- a/qgisfeedproject/templates/layouts/base-fullscreen.html
+++ b/qgisfeedproject/templates/layouts/base-fullscreen.html
@@ -20,6 +20,7 @@
     <script type="text/javascript" src="{% static "js/moment.min.js" %}"></script>
 
     <script type="text/javascript" src="https://qgis.github.io/qgis-uni-navigation/index.js"></script>
+    <script type="text/javascript" src="{% static "js/bulma.js" %}"></script>
 
     {% load render_bundle from webpack_loader %}
     {% render_bundle 'main' %}


### PR DESCRIPTION
Fix for #112 

- Draft guidelines for entry submissions.
- Clicking on the new entry button will show the guidelines
- Set default feed duration to 10 days
- Only approvers can check the entry as sticky
- Also show the guidelines to the review modal

![image](https://github.com/user-attachments/assets/b3a36f8b-0a15-42f8-a794-f010fcb0d8b9)

![image](https://github.com/user-attachments/assets/33da8e8f-9d7a-4307-b844-a4107ad2fc6c)
