### PR TITLE
Add the sustaining members section to the homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ package-lock.json
 webpack-stats.json
 qgisfeedproject/static/bundles
 !qgisfeedproject/qgisfeedproject/settings_local.py.templ
+
+# Sustaining members template
+qgisfeedproject/templates/layouts/sustaining_members.html

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,14 @@ collectstatic:
 	@docker compose -f docker-compose-production-ssl.yml exec $(CONTAINER_NAME) python qgisfeedproject/manage.py collectstatic --noinput
 
 
+get-sustaining-members:
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Getting sustaining members section"
+	@echo "------------------------------------------------------------------"
+	@docker compose -f docker-compose-production-ssl.yml exec $(CONTAINER_NAME) python qgisfeedproject/manage.py get_sustaining_members
+
+
 qgisfeed-shell:
 	@echo
 	@echo "------------------------------------------------------------------"

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -4,6 +4,7 @@ asgiref~=3.7
 async-timeout~=4.0
 asynctest~=0.13
 attrs~=21.4
+beautifulsoup4~=4.12
 certifi~=2021.10
 charset-normalizer~=2.0
 Django~=4.2

--- a/qgisfeedproject/qgisfeed/management/commands/get_sustaining_members.py
+++ b/qgisfeedproject/qgisfeed/management/commands/get_sustaining_members.py
@@ -1,0 +1,32 @@
+from django.core.management.base import BaseCommand
+import requests
+from bs4 import BeautifulSoup
+from django.conf import settings
+import os
+
+class Command(BaseCommand):
+    help = "Get the Sustaining members HTML section from the new website"
+
+    def handle(self, *args, **options):
+        try:
+            url = 'https://qgis.org'
+            response = requests.get(url)
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, 'html.parser')
+
+            # Extract the section by the specified class name
+            section = soup.select_one('section.section')
+
+            if section:
+                html_content = section.prettify().replace("Â¶", "¶")
+                template_path = os.path.join(
+                    os.path.dirname(settings.SITE_ROOT),
+                    'templates/layouts/sustaining_members.html'
+                )
+                with open(template_path, 'w') as f:
+                    f.write(html_content)
+                self.stdout.write(self.style.SUCCESS(f"Section saved to {template_path}"))
+            else:
+                self.stdout.write(self.style.WARNING("Section not found"))
+        except requests.RequestException as e:
+            self.stdout.write(self.style.ERROR(f"Request error: {e}"))

--- a/qgisfeedproject/qgisfeed/templatetags/feed_utils.py
+++ b/qgisfeedproject/qgisfeed/templatetags/feed_utils.py
@@ -1,0 +1,22 @@
+from django import template
+import os.path
+from django.conf import settings
+
+register = template.Library()
+
+@register.simple_tag
+def get_sustaining_members_section():
+    """
+    Get the Sustaining members HTML from the template file
+    """
+    print(settings.SITE_ROOT)
+    template_path = os.path.join(
+      os.path.dirname(settings.SITE_ROOT),
+      'templates/layouts/sustaining_members.html'
+    )
+    print(os.path.exists(template_path))
+    try:
+        with open(template_path, 'r') as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""

--- a/qgisfeedproject/qgisfeedproject/settings.py
+++ b/qgisfeedproject/qgisfeedproject/settings.py
@@ -53,7 +53,7 @@ INSTALLED_APPS = [
     'user_visit',
 
     # Webpack
-    'webpack_loader'
+    'webpack_loader',
 ]
 
 # Useful debugging extensions

--- a/qgisfeedproject/static/style/scss/style.scss
+++ b/qgisfeedproject/static/style/scss/style.scss
@@ -3,6 +3,10 @@
 @import "custom.bulma.scss";
 @import "sustaining_members.scss";
 
+html {
+  scroll-padding-top: 120px; /* height of your fixed header */
+}
+
 body {
   color: $text-primary1;
   font-weight: 300;
@@ -305,4 +309,17 @@ p {
 
 .rounded .rich-right img {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+a.heading-anchor {
+  visibility: hidden;
+}
+
+h1:hover > a.heading-anchor,
+h2:hover > a.heading-anchor,
+h3:hover > a.heading-anchor,
+h4:hover > a.heading-anchor,
+h5:hover > a.heading-anchor,
+h6:hover > a.heading-anchor {
+  visibility: visible;
 }

--- a/qgisfeedproject/templates/layouts/base-fullscreen.html
+++ b/qgisfeedproject/templates/layouts/base-fullscreen.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static feed_utils %}
 
 <!DOCTYPE html>
 <html lang="en" class="has-navbar-fixed-top">
@@ -44,6 +44,9 @@
             {% block content %}{% endblock content %}
         </div>
     </section>
+
+    {% get_sustaining_members_section as sustaining_members_section %}
+    {{ sustaining_members_section|safe }}
 
     {% include 'layouts/footer.html' %}
 


### PR DESCRIPTION
Fix for #103 

## Requirements:

- Trigger the image build to create a new image on Docker Hub, as we implemented a new dependency 
- Add this line to the cronjob: 
```
0 0 * * * docker exec qgisfeed python /code/qgisfeedproject/manage.py get_sustaining_members
```