### PR TITLE
Accept multiple comma-separated language codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,11 +286,11 @@ Example call: http://localhost:8000/?after=1557419013
 
 #### lang
 
-When `lang` is passed, the records that have a different `lang` will be excluded from the results. Only the records with `null` `lang` and the records with a matching `lang` will be returned.
+When `lang` is passed, you can specify one or more language codes as a comma-separated list. Only records with a matching `lang` or `null` `lang` will be returned; records with non-matching languages are excluded.
 
-Accepted values: `ISO-939-1` two letters language code
+Accepted values: Comma-separated list of `ISO-639-1` two-letter language codes
 
-Example call: http://localhost:8000/?lang=de
+Example call: http://localhost:8000/?lang=de,fr,it
 
 #### lat lon (location)
 

--- a/qgisfeedproject/qgisfeed/tests.py
+++ b/qgisfeedproject/qgisfeed/tests.py
@@ -132,6 +132,13 @@ class QgisFeedEntryTestCase(TestCase):
         titles = [d['title'] for d in data]
         self.assertTrue("Null Island QGIS Meeting" in titles)
         self.assertTrue("QGIS acquired by ESRI" in titles)
+
+        # Test with multiple languages (comma separated)
+        response = c.get('/?lang=en,fr')
+        data = json.loads(response.content)
+        titles = [d['title'] for d in data]
+        self.assertTrue("Null Island QGIS Meeting" in titles)
+        self.assertTrue("QGIS acquired by ESRI" in titles)
     
     def test_lang_and_location_filter(self):
         # Test with lang (id) and location filter (Indonesia)


### PR DESCRIPTION
Closes #124 

When `lang` is passed, you can specify one or more language codes as a comma-separated list. Only records with a matching `lang` or `null` `lang` will be returned; records with non-matching languages are excluded.

Accepted values: Comma-separated list of `ISO-639-1` two-letter language codes

Example call: http://localhost:8000/?lang=de,fr,it