### PR TITLE
Refactor MEDIA_ROOT and STATIC_ROOT to use environment variables

### DIFF
--- a/settings_docker_production.py
+++ b/settings_docker_production.py
@@ -1,26 +1,25 @@
-
 # Settings local for docker compose production settings
 import os
 
-DEBUG=False
+DEBUG = False
 
-ALLOWED_HOSTS=['*']
+ALLOWED_HOSTS = ["*"]
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'NAME':  os.getenv('QGISFEED_DOCKER_DBNAME', 'qgisfeed'),
-        'USER': os.getenv('QGISFEED_DOCKER_DBUSER', 'docker'),
-        'PASSWORD': os.getenv('QGISFEED_DOCKER_DBPASSWORD', 'docker'),
-        'HOST': os.getenv('QGISFEED_DOCKER_DBHOST', 'postgis'),
-        'PORT': '5432'
+    "default": {
+        "ENGINE": "django.contrib.gis.db.backends.postgis",
+        "NAME": os.getenv("QGISFEED_DOCKER_DBNAME", "qgisfeed"),
+        "USER": os.getenv("QGISFEED_DOCKER_DBUSER", "docker"),
+        "PASSWORD": os.getenv("QGISFEED_DOCKER_DBPASSWORD", "docker"),
+        "HOST": os.getenv("QGISFEED_DOCKER_DBHOST", "postgis"),
+        "PORT": "5432",
     }
 }
 
-MEDIA_ROOT = '/shared-volume/media/'
-MEDIA_URL = '/media/'
-STATIC_ROOT = '/shared-volume/static/'
-STATIC_URL = '/static/'
+MEDIA_ROOT = os.getenv("MEDIA_ROOT", "/shared-volume/media/")
+MEDIA_URL = "/media/"
+STATIC_ROOT = os.getenv("STATIC_ROOT", "/shared-volume/static/")
+STATIC_URL = "/static/"
 
 if not os.path.exists(MEDIA_ROOT):
     os.mkdir(MEDIA_ROOT)
@@ -32,6 +31,8 @@ if not os.path.exists(STATIC_ROOT):
 USE_X_FORWARDED_PORT = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-QGIS_FEED_PROD_URL = os.environ.get('QGIS_FEED_PROD_URL', False)
-CSRF_TRUSTED_ORIGINS = [p + QGIS_FEED_PROD_URL for p in ['http://', 'https://'] if QGIS_FEED_PROD_URL]
+QGIS_FEED_PROD_URL = os.environ.get("QGIS_FEED_PROD_URL", False)
+CSRF_TRUSTED_ORIGINS = [
+    p + QGIS_FEED_PROD_URL for p in ["http://", "https://"] if QGIS_FEED_PROD_URL
+]
 CORS_ORIGIN_WHITELIST = CSRF_TRUSTED_ORIGINS


### PR DESCRIPTION
Adjustments to apply @imincik patches at https://github.com/qgis/QGIS-Feed-Website/commit/65148bde1ec8404729fadf7c2a64537a9d50dc61

Get `MEDIA_ROOT` and `STATIC_ROOT` from the environment variable and fallback to the current default values.