### PR TITLE
Handle double click call for action text in QGIS 4

### DIFF
--- a/qgisfeedproject/qgisfeed/forms.py
+++ b/qgisfeedproject/qgisfeed/forms.py
@@ -115,6 +115,7 @@ class FeedItemForm(forms.ModelForm):
             "image",
             "content",
             "url",
+            "action_text",
             "sticky",
             "sorting",
             "language_filter",
@@ -158,6 +159,12 @@ class FeedItemForm(forms.ModelForm):
         )
         self.fields["url"].widget = forms.TextInput(
             attrs={"class": "input", "placeholder": "URL for more information link"}
+        )
+        self.fields["action_text"].widget = forms.TextInput(
+            attrs={
+                "class": "input",
+                "placeholder": "e.g. Double-click here to read more (QGIS 3 only)",
+            }
         )
         self.fields["sorting"].widget = forms.NumberInput(
             attrs={

--- a/qgisfeedproject/qgisfeed/migrations/0019_qgisfeedentry_action_text.py
+++ b/qgisfeedproject/qgisfeed/migrations/0019_qgisfeedentry_action_text.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("qgisfeed", "0018_alter_feedentryreview_options"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="qgisfeedentry",
+            name="action_text",
+            field=models.CharField(
+                blank=True,
+                help_text=(
+                    "Optional call-to-action shown only on QGIS 3 (e.g. 'Double-click here to read more'). "
+                    "Leave blank if not needed. QGIS 4 opens the URL via a dedicated button so this text is hidden there."
+                ),
+                max_length=255,
+                null=True,
+                verbose_name="Call to action text",
+            ),
+        ),
+    ]

--- a/qgisfeedproject/qgisfeed/models.py
+++ b/qgisfeedproject/qgisfeed/models.py
@@ -124,6 +124,16 @@ class QgisFeedEntry(models.Model):
         blank=True,
         null=True,
     )
+    action_text = models.CharField(
+        _("Call to action text"),
+        max_length=255,
+        blank=True,
+        null=True,
+        help_text=_(
+            "Optional call-to-action shown only on QGIS 3 (e.g. 'Double-click here to read more'). "
+            "Leave blank if not needed. QGIS 4 opens the URL via a dedicated button so this text is hidden there."
+        ),
+    )
 
     # Auto fields
     author = models.ForeignKey(

--- a/qgisfeedproject/qgisfeed/tests.py
+++ b/qgisfeedproject/qgisfeed/tests.py
@@ -311,6 +311,63 @@ class QgisFeedEntryTestCase(TestCase):
             set(("qgisfeed.add_qgisfeedentry", "qgisfeed.view_qgisfeedentry")),
         )
 
+    def test_action_text_shown_on_qgis3_hidden_on_qgis4(self):
+        """action_text must be appended to content for QGIS 3 clients and
+        omitted for QGIS 4+ clients, regardless of the language used."""
+        author = User.objects.get(username="admin")
+        entry = QgisFeedEntry.objects.create(
+            title="Action-text test entry",
+            content="<p>Some real content here.</p>",
+            action_text="Double-cliquez ici pour en savoir plus.",
+            url="https://www.example.com",
+            author=author,
+            status=QgisFeedEntry.PUBLISHED,
+            publish_from="2019-05-05T12:00:00Z",
+        )
+
+        # --- QGIS 3 client ---
+        c3 = Client(
+            HTTP_USER_AGENT="Mozilla/5.0 QGIS/33600/Fedora Linux (Workstation Edition)"
+        )
+        response = c3.get("/")
+        data = json.loads(response.content)
+
+        # action_text appended for QGIS 3
+        match = next((d for d in data if d["title"] == "Action-text test entry"), None)
+        self.assertIsNotNone(match)
+        self.assertIn("Double-cliquez ici pour en savoir plus.", match["content"])
+        self.assertIn("Some real content here", match["content"])
+
+        # --- QGIS 4 client ---
+        c4 = Client(
+            HTTP_USER_AGENT="Mozilla/5.0 QGIS/40000/Fedora Linux (Workstation Edition)"
+        )
+        response = c4.get("/")
+        data = json.loads(response.content)
+
+        # action_text must NOT appear in content for QGIS 4
+        match = next((d for d in data if d["title"] == "Action-text test entry"), None)
+        self.assertIsNotNone(match)
+        self.assertNotIn("Double-cliquez ici pour en savoir plus.", match["content"])
+        self.assertIn("Some real content here", match["content"])
+        self.assertNotIn("action_text", match)
+
+        # Entry with no action_text: content unchanged for all versions
+        entry_no_action = QgisFeedEntry.objects.create(
+            title="No-action-text entry",
+            content="<p>Plain content.</p>",
+            action_text=None,
+            url="https://www.example.com",
+            author=author,
+            status=QgisFeedEntry.PUBLISHED,
+            publish_from="2019-05-05T12:00:00Z",
+        )
+        response = c4.get("/")
+        data = json.loads(response.content)
+        match = next((d for d in data if d["title"] == "No-action-text entry"), None)
+        self.assertIsNotNone(match)
+        self.assertEqual(match["content"], "<p>Plain content.</p>")
+
     def test_admin_publish_from(self):
         """Test that published entries have publish_from set"""
 

--- a/qgisfeedproject/qgisfeed/utils.py
+++ b/qgisfeedproject/qgisfeed/utils.py
@@ -373,6 +373,7 @@ def create_revision_snapshot(original_entry, new_instance, user):
     TRACKED_FIELDS = [
         ("title", "Title", "text"),
         ("url", "URL", "text"),
+        ("action_text", "Call to Action Text", "text"),
         ("content", "Content", "content"),
         ("image", "Image", "file"),
         ("sticky", "Sticky", "bool"),

--- a/qgisfeedproject/qgisfeed/views.py
+++ b/qgisfeedproject/qgisfeed/views.py
@@ -226,6 +226,7 @@ class QgisEntriesView(View):
             "image",
             "content",
             "url",
+            "action_text",
             "sticky",
         )[:QGISFEED_MAX_RECORDS]:
             if record["publish_from"]:
@@ -236,6 +237,16 @@ class QgisEntriesView(View):
                 record["image"] = request.build_absolute_uri(
                     settings.MEDIA_URL + record["image"]
                 )
+            # action_text is a QGIS-3-only call-to-action (e.g. "Double-click
+            # here to read more").  For QGIS 4+ the UI provides its own
+            # interaction affordance so we omit it; for older clients we
+            # append it to the content so they still see it.
+            action_text = record.pop("action_text", None)
+            if action_text and (qgis_version is None or qgis_version < 40000):
+                record["content"] = (
+                    record["content"] or ""
+                ) + f"<p><strong>{action_text}</strong></p>"
+
             data.append(record)
 
         data_json = json.dumps(data, indent=(2 if settings.DEBUG else 0))

--- a/qgisfeedproject/templates/feeds/feed_item_form.html
+++ b/qgisfeedproject/templates/feeds/feed_item_form.html
@@ -522,7 +522,7 @@
 
     // Tab switching functionality using Bulma tabs
     document.addEventListener('DOMContentLoaded', () => {
-        const tabItems = document.querySelectorAll('.tabs li');
+        const tabItems = document.querySelectorAll('.tabs li[data-tab]');
         const tabContents = document.querySelectorAll('.tab-content');
 
         tabItems.forEach(item => {

--- a/qgisfeedproject/templates/feeds/feed_item_form_widgets.html
+++ b/qgisfeedproject/templates/feeds/feed_item_form_widgets.html
@@ -86,6 +86,23 @@
       </div>
     </div>
     <div class="columns">
+      <div class="column is-12 field">
+        <label class="label">
+          {{ form.action_text.label_tag }}
+        </label>
+        <div class="control has-icons-left">
+          {{form.action_text}}
+          <span class="icon is-small is-left">
+            <i class="fas fa-hand-pointer"></i>
+          </span>
+        </div>
+        <p class="help">{{form.action_text.help_text}}</p>
+        {% for error in form.action_text.errors %}
+          <p class="help form-error">{{ error }}</p>
+        {% endfor %}
+      </div>
+    </div>
+    <div class="columns">
       <div class="column is-6 field">
         <label class="label">
           {% if form.sorting.field.required %}

--- a/qgisfeedproject/templates/feeds/feed_item_preview.html
+++ b/qgisfeedproject/templates/feeds/feed_item_preview.html
@@ -1,19 +1,70 @@
-<div class="form-preview columns has-background-light box-container m-0">
-    <div class="column is-4" name="imagePreview">
-        {% if form.image.value %}
-        <img src="{{ form.image.value.url }}" style="border-radius:20px;">
-        {% else %}
-        {% endif %}
-    </div>
-    <div class="column is-8">
-        <h5 name="titlePreview" class="title is-5">
-            {{form.title.value | default:""}}
-        </h5>
-        <div name="contentPreview">
-            {{form.content.value | default:"" | safe }}
+<div class="preview-version-container">
+<div class="tabs is-toggle is-small mb-3">
+    <ul class="preview-version-tabs is-justify-content-center">
+        <li class="is-active" data-preview="qgis3">
+            <a><span>QGIS 3 preview</span></a>
+        </li>
+        <li data-preview="qgis4">
+            <a><span>QGIS 4 preview</span></a>
+        </li>
+    </ul>
+</div>
+
+<div class="preview-pane preview-qgis3">
+    <div class="form-preview columns has-background-light box-container m-0">
+        <div class="column is-4" name="imagePreview">
+            {% if form.image.value %}
+            <img src="{{ form.image.value.url }}" style="border-radius:20px;">
+            {% endif %}
+        </div>
+        <div class="column is-8">
+            <h5 name="titlePreview" class="title is-5">
+                {{form.title.value | default:""}}
+            </h5>
+            <div name="contentPreview">
+                {{form.content.value | default:"" | safe }}
+            </div>
+            {% if form.action_text.value %}
+            <p name="actionTextPreview" class="mt-2"><strong>{{ form.action_text.value }}</strong></p>
+            {% endif %}
         </div>
     </div>
 </div>
+
+<div class="preview-pane preview-qgis4" style="display:none;">
+    <div class="form-preview columns has-background-light box-container m-0">
+        <div class="column is-4" name="imagePreview">
+            {% if form.image.value %}
+            <img src="{{ form.image.value.url }}" style="border-radius:20px;">
+            {% endif %}
+        </div>
+        <div class="column is-8">
+            <h5 class="title is-5">
+                {{form.title.value | default:""}}
+            </h5>
+            <div>
+                {{form.content.value | default:"" | safe }}
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+(function () {
+    var container = document.currentScript.closest('.preview-version-container');
+    var tabs = container.querySelectorAll('.preview-version-tabs li');
+    tabs.forEach(function (tab) {
+        tab.addEventListener('click', function () {
+            tabs.forEach(function (t) { t.classList.remove('is-active'); });
+            tab.classList.add('is-active');
+            container.querySelectorAll('.preview-pane').forEach(function (p) {
+                p.style.display = 'none';
+            });
+            container.querySelector('.preview-' + tab.dataset.preview).style.display = '';
+        });
+    });
+}());
+</script>
 
 <div class="form-preview columns box-container m-0">
     <table class="table is-fullwidth">
@@ -73,3 +124,4 @@
         </tbody>
     </table>
 </div>
+</div><!-- /.preview-version-container -->


### PR DESCRIPTION
Closes #165 

## Problem

QGIS 3 displays feed entries in a rich item panel where double-clicking opens the entry URL. To guide users, authors commonly write phrases like *"Double-click here to read more"* directly in the entry content.

QGIS 4 changed the interaction model — the URL is now opened via a dedicated button, so double-click no longer does anything. As a result, those call-to-action phrases are shown to QGIS 4 users even though they are meaningless and potentially confusing.

## Why not regex stripping?

The obvious quick fix would be to detect a QGIS 4 user-agent on the server and strip double-click hint phrases from the `content` field with a regex before returning the JSON response. We explicitly rejected this approach for several reasons:

- **Multilingual content** — the feed is used worldwide. "Double-cliquez ici", "Doppelklicken Sie hier", "Haga doble clic" and dozens of other translations cannot all be reliably captured by a regex without false positives and maintenance overhead.
- **Fragility** — regex matching against free-form HTML is inherently brittle. A phrase split across HTML tags, or wrapped in `<strong>`, would silently survive the strip.
- **Author intent is ambiguous** — the server cannot know whether a sentence that happens to contain the word "click" is a navigation hint or genuine editorial content.
- **No audit trail** — silently mutating stored content at read time makes debugging very hard and produces no visible indication to the author that their text was suppressed.

## Solution

A new optional `action_text` field is added to the `QgisFeedEntry` model. Authors use it to supply their call-to-action phrase explicitly and separately from the main content. The server then:

- **Appends** `<p><strong>{action_text}</strong></p>` to `content` for QGIS 3 clients (version < 40000), preserving existing behaviour.
- **Omits** it entirely for QGIS 4+ clients, where the UI provides its own affordance for opening the URL.
- **Never leaks** the raw `action_text` key into the JSON response — it is always `pop()`-ed from the record before serialisation.

This keeps the separation of concerns clean: the content field holds editorial content, and the call-to-action is a distinct, explicitly-authored, version-aware signal.

**NOTE**: This new implementation will not automatically handle existing entries. A manual modification is needed on the form to specify the new field and remove call for action from the content.