### PR TITLE
Add publication state logic for feed entries and update display in templates

### DIFF
--- a/qgisfeedproject/qgisfeed/models.py
+++ b/qgisfeedproject/qgisfeed/models.py
@@ -253,6 +253,19 @@ class QgisFeedEntry(models.Model):
             return self.publish_from.timestamp()
         return 0
 
+    @property
+    def publication_state(self):
+        """Return the publication state for published entries.
+        Returns 'upcoming', 'live', or 'expired', or None for non-published entries."""
+        if self.status != self.PUBLISHED:
+            return None
+        now = timezone.now()
+        if self.publish_from and self.publish_from > now:
+            return "upcoming"
+        if self.publish_to and self.publish_to < now:
+            return "expired"
+        return "live"
+
     def __str__(self):
         return self.title
 

--- a/qgisfeedproject/templates/feeds/feed_item_form.html
+++ b/qgisfeedproject/templates/feeds/feed_item_form.html
@@ -101,13 +101,46 @@
         {% if form.title.value %}
             Edit feed entry
             {% if feed_entry %}
-            <span class="tag {% if feed_entry.status == 'published' %}is-success
-                              {% elif feed_entry.status == 'approved' %}is-primary
-                              {% elif feed_entry.status == 'pending_review' %}is-warning
-                              {% elif feed_entry.status == 'changes_requested' %}is-danger
-                              {% else %}is-light{% endif %}">
-                {{ feed_entry.get_status_display }}
-            </span>
+            {% if feed_entry.status == 'published' %}
+              {% if feed_entry.publication_state == 'upcoming' %}
+                <span class="tag is-info">
+                  <span class="icon is-small mr-1"><i class="fas fa-clock"></i></span>
+                  Upcoming
+                </span>
+              {% elif feed_entry.publication_state == 'expired' %}
+                <span class="tag is-light">
+                  <span class="icon is-small mr-1"><i class="fas fa-calendar-xmark"></i></span>
+                  Expired
+                </span>
+              {% else %}
+                <span class="tag is-success">
+                  <span class="icon is-small mr-1"><i class="fas fa-circle-check"></i></span>
+                  Live
+                </span>
+              {% endif %}
+            {% else %}
+              {% if feed_entry.status == 'approved' %}
+                <span class="tag is-primary">
+                  <span class="icon is-small mr-1"><i class="fas fa-check"></i></span>
+                  {{ feed_entry.get_status_display }}
+                </span>
+              {% elif feed_entry.status == 'pending_review' %}
+                <span class="tag is-warning">
+                  <span class="icon is-small mr-1"><i class="fas fa-hourglass-half"></i></span>
+                  {{ feed_entry.get_status_display }}
+                </span>
+              {% elif feed_entry.status == 'changes_requested' %}
+                <span class="tag is-danger">
+                  <span class="icon is-small mr-1"><i class="fas fa-exclamation-triangle"></i></span>
+                  {{ feed_entry.get_status_display }}
+                </span>
+              {% else %}
+                <span class="tag is-light">
+                  <span class="icon is-small mr-1"><i class="fas fa-file-pen"></i></span>
+                  {{ feed_entry.get_status_display }}
+                </span>
+              {% endif %}
+            {% endif %}
             {% endif %}
         {% else %}
             New feed entry

--- a/qgisfeedproject/templates/feeds/feeds_list.html
+++ b/qgisfeedproject/templates/feeds/feeds_list.html
@@ -233,13 +233,46 @@
                     {% endif %}
                   </td>
                   <td>
-                    <span class="tag {% if feed.status == 'published' %}is-success
-                                      {% elif feed.status == 'approved' %}is-primary
-                                      {% elif feed.status == 'pending_review' %}is-warning
-                                      {% elif feed.status == 'changes_requested' %}is-danger
-                                      {% else %}is-light{% endif %}">
-                        {{ feed.get_status_display }}
-                    </span>
+                    {% if feed.status == 'published' %}
+                      {% if feed.publication_state == 'upcoming' %}
+                        <span class="tag is-info">
+                          <span class="icon is-small mr-1"><i class="fas fa-clock"></i></span>
+                          Upcoming
+                        </span>
+                      {% elif feed.publication_state == 'expired' %}
+                        <span class="tag is-light">
+                          <span class="icon is-small mr-1"><i class="fas fa-calendar-xmark"></i></span>
+                          Expired
+                        </span>
+                      {% else %}
+                        <span class="tag is-success">
+                          <span class="icon is-small mr-1"><i class="fas fa-circle-check"></i></span>
+                          Live
+                        </span>
+                      {% endif %}
+                    {% else %}
+                      {% if feed.status == 'approved' %}
+                        <span class="tag is-primary">
+                          <span class="icon is-small mr-1"><i class="fas fa-check"></i></span>
+                          {{ feed.get_status_display }}
+                        </span>
+                      {% elif feed.status == 'pending_review' %}
+                        <span class="tag is-warning">
+                          <span class="icon is-small mr-1"><i class="fas fa-hourglass-half"></i></span>
+                          {{ feed.get_status_display }}
+                        </span>
+                      {% elif feed.status == 'changes_requested' %}
+                        <span class="tag is-danger">
+                          <span class="icon is-small mr-1"><i class="fas fa-exclamation-triangle"></i></span>
+                          {{ feed.get_status_display }}
+                        </span>
+                      {% else %}
+                        <span class="tag is-light">
+                          <span class="icon is-small mr-1"><i class="fas fa-file-pen"></i></span>
+                          {{ feed.get_status_display }}
+                        </span>
+                      {% endif %}
+                    {% endif %}
                   </td>
 
                   <td>{{ feed.publish_from|date:"Y-m-d, H:i"|default:"-" }}</td>


### PR DESCRIPTION
Add different states to published items (upcoming, live, expired) so we will have seven different status.

<img width="150" alt="image" src="https://github.com/user-attachments/assets/3c004658-3879-49bf-80f3-c9a342d517a2" />


Co-authored-by: Copilot <copilot@github.com>
