### PR TITLE
Add clone functionality for feed entries with corresponding tests and UI integration

### DIFF
--- a/qgisfeedproject/qgisfeed/tests.py
+++ b/qgisfeedproject/qgisfeed/tests.py
@@ -1869,3 +1869,98 @@ class RevisionSnapshotTestCase(TestCase):
         # Revision was created first so it must come first in the sorted list
         self.assertEqual(history[0]["type"], "revision")
         self.assertEqual(history[1]["type"], "review")
+
+
+class FeedEntryCloneViewTestCase(TestCase):
+    """Tests for the clone feed entry feature."""
+
+    fixtures = ["qgisfeed.json", "users.json"]
+
+    def setUp(self):
+        self.client = Client()
+        self.admin = User.objects.get(username="admin")
+        self.staff = User.objects.get(username="staff")
+        # Use an existing published, expired entry from fixtures
+        self.entry = QgisFeedEntry.objects.get(pk=3)
+
+    def test_clone_creates_new_entry(self):
+        """Cloning an entry creates a new entry with the same content."""
+        self.client.login(username="admin", password="admin")
+        original_count = QgisFeedEntry.objects.count()
+
+        response = self.client.get(reverse("feed_entry_clone", args=[self.entry.pk]))
+
+        self.assertEqual(QgisFeedEntry.objects.count(), original_count + 1)
+        clone = QgisFeedEntry.objects.order_by("-pk").first()
+        self.assertNotEqual(clone.pk, self.entry.pk)
+        self.assertEqual(clone.content, self.entry.content)
+        self.assertEqual(clone.url, self.entry.url)
+
+    def test_clone_title_prefixed(self):
+        """The cloned entry title is prefixed with 'Copy of'."""
+        self.client.login(username="admin", password="admin")
+        response = self.client.get(reverse("feed_entry_clone", args=[self.entry.pk]))
+
+        clone = QgisFeedEntry.objects.order_by("-pk").first()
+        self.assertEqual(clone.title, f"Copy of {self.entry.title}")
+
+    def test_clone_dates_prefilled(self):
+        """The cloned entry has publication dates pre-filled like a new entry."""
+        before = timezone.now()
+        self.client.login(username="admin", password="admin")
+        response = self.client.get(reverse("feed_entry_clone", args=[self.entry.pk]))
+        after = timezone.now()
+
+        clone = QgisFeedEntry.objects.order_by("-pk").first()
+        self.assertIsNotNone(clone.publish_from)
+        self.assertIsNotNone(clone.publish_to)
+        self.assertGreaterEqual(clone.publish_from, before)
+        self.assertLessEqual(clone.publish_from, after)
+        self.assertAlmostEqual(
+            (clone.publish_to - clone.publish_from).days, 10, delta=1
+        )
+
+    def test_clone_status_is_draft_and_unpublished(self):
+        """The cloned entry is a draft and not published."""
+        self.client.login(username="admin", password="admin")
+        response = self.client.get(reverse("feed_entry_clone", args=[self.entry.pk]))
+
+        clone = QgisFeedEntry.objects.order_by("-pk").first()
+        self.assertEqual(clone.status, QgisFeedEntry.DRAFT)
+        self.assertFalse(clone.published)
+
+    def test_clone_author_is_current_user(self):
+        """The clone's author is set to the currently logged-in user."""
+        self.client.login(username="admin", password="admin")
+        response = self.client.get(reverse("feed_entry_clone", args=[self.entry.pk]))
+
+        clone = QgisFeedEntry.objects.order_by("-pk").first()
+        self.assertEqual(clone.author, self.admin)
+
+    def test_clone_redirects_to_edit_form(self):
+        """After cloning, the user is redirected to the edit form for the new entry."""
+        self.client.login(username="admin", password="admin")
+        response = self.client.get(reverse("feed_entry_clone", args=[self.entry.pk]))
+
+        clone = QgisFeedEntry.objects.order_by("-pk").first()
+        self.assertRedirects(response, reverse("feed_entry_update", args=[clone.pk]))
+
+    def test_unauthenticated_user_cannot_clone(self):
+        """An unauthenticated user is redirected to the login page."""
+        response = self.client.get(reverse("feed_entry_clone", args=[self.entry.pk]))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("login"), response["Location"])
+
+    def test_nonstaff_user_cannot_clone(self):
+        """A non-staff user is redirected to the login page."""
+        user = User.objects.create_user(username="testuser2", password="testpass2")
+        self.client.login(username="testuser2", password="testpass2")
+        response = self.client.get(reverse("feed_entry_clone", args=[self.entry.pk]))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("login"), response["Location"])
+
+    def test_clone_nonexistent_entry_returns_404(self):
+        """Cloning a non-existent entry returns a 404."""
+        self.client.login(username="admin", password="admin")
+        response = self.client.get(reverse("feed_entry_clone", args=[99999]))
+        self.assertEqual(response.status_code, 404)

--- a/qgisfeedproject/qgisfeed/urls.py
+++ b/qgisfeedproject/qgisfeed/urls.py
@@ -33,4 +33,9 @@ urlpatterns = [
         views.FeedEntryShareTelegramView.as_view(),
         name="feed_entry_share_telegram",
     ),
+    path(
+        "manage/clone/<int:pk>/",
+        views.FeedEntryCloneView.as_view(),
+        name="feed_entry_clone",
+    ),
 ]

--- a/qgisfeedproject/qgisfeed/views.py
+++ b/qgisfeedproject/qgisfeed/views.py
@@ -945,3 +945,37 @@ class FeedEntryShareTelegramView(View):
                 request, f"Error sharing to Telegram: {str(e)}", fail_silently=True
             )
         return redirect("feeds_list")
+
+
+@method_decorator(staff_required, name="dispatch")
+@method_decorator(permission_required("qgisfeed.add_qgisfeedentry"), name="dispatch")
+class FeedEntryCloneView(View):
+    """
+    View to clone an existing feed entry.
+    Creates a new draft entry with the same content but cleared publication
+    dates, a new primary key, and the current user as author.
+    The user is redirected to the edit form so they can adjust the entry
+    before submitting it for review or publishing.
+    """
+
+    def get(self, request, pk):
+        original = get_object_or_404(QgisFeedEntry, pk=pk)
+        original_title = original.title
+
+        # Setting pk/id to None then calling save() makes Django INSERT a new row.
+        original.pk = None
+        original.id = None
+        original.title = f"Copy of {original_title}"
+        original.published = False
+        original.status = QgisFeedEntry.DRAFT
+        original.publish_from = timezone.now()
+        original.publish_to = timezone.now() + timezone.timedelta(days=10)
+        original.author = request.user
+        original.save()
+
+        messages.success(
+            request,
+            f"Entry '{original_title}' cloned successfully. "
+            "Please update the dates and content before publishing.",
+        )
+        return redirect("feed_entry_update", pk=original.pk)

--- a/qgisfeedproject/qgisfeed/views.py
+++ b/qgisfeedproject/qgisfeed/views.py
@@ -975,7 +975,7 @@ class FeedEntryCloneView(View):
 
         messages.success(
             request,
-            f"Entry '{original_title}' cloned successfully. "
-            "Please update the dates and content before publishing.",
+            f"Entry <b>{original_title}</b> cloned successfully. "
+            "Please <b> check/update the title</b> and any other values before submitting for review.",
         )
         return redirect("feed_entry_update", pk=original.pk)

--- a/qgisfeedproject/templates/feeds/feed_item_form.html
+++ b/qgisfeedproject/templates/feeds/feed_item_form.html
@@ -152,6 +152,14 @@
         </span>
         <span>Back to the list</span>
     </a>
+    {% if feed_entry %}
+    <a href="{% url 'feed_entry_clone' pk=feed_entry.pk %}" class="button is-info is-outlined ml-2">
+        <span class="icon">
+            <i class="fas fa-copy"></i>
+        </span>
+        <span>Clone</span>
+    </a>
+    {% endif %}
 
     <div class="mt-5">
         <div class="tabs is-boxed">


### PR DESCRIPTION
Closes #178 

- Add a "Clone" button to each item
- Cloning an item will:
  - Create a new item prefilled with the same values except for title and dates
  - Pop a notification that the item has been cloned and check/update the values before submitting for review
  - Title will contain "Copy of..."
  - Dates will be pre-set to the next 10 days

Original entry:
<img width="1378" height="463" alt="image" src="https://github.com/user-attachments/assets/44202cba-187e-46e4-a884-b718db5d018b" />

Cloned entry:

<img width="1372" height="446" alt="image" src="https://github.com/user-attachments/assets/c0617030-89d7-443e-a171-9061d8323205" />
